### PR TITLE
Add Recurse option within Copy-LogmanData function

### DIFF
--- a/ExchangeLogCollector.ps1
+++ b/ExchangeLogCollector.ps1
@@ -2656,7 +2656,7 @@ param(
                 Write-ScriptDebug("Updating Copy From Date to: '{0}'" -f $filterDate)
             }
 
-            $childItems = Get-ChildItem $strDirectory | ?{($_.Name -like $wildExt) -and ($_.CreationTime -ge $filterDate)}
+            $childItems = Get-ChildItem $strDirectory -Recurse | ?{($_.Name -like $wildExt) -and ($_.CreationTime -ge $filterDate)}
             $items = @()
             foreach($childItem in $childItems)
             {


### PR DESCRIPTION
Add the -Recurse switch to the Get-ChildItem command when trying to copy off ExPerfWiz data from Exchange Servers.

Without this option the result is a warning message that "Failed to find any files in the directory: 'C:\Temp\ExPerfwiz\' that was greater than or equal to this time: 1/6/2021" even though these files exist in subfolders.