### PR TITLE
Removed Changing of Error Action Preferences

### DIFF
--- a/src/ExchangeLogCollector/ExchangeLogCollector.ps1
+++ b/src/ExchangeLogCollector/ExchangeLogCollector.ps1
@@ -252,8 +252,6 @@ Function Invoke-RemoteFunctions {
     . .\RemoteScriptBlock\Logman\Stop-Logman.ps1
     . .\RemoteScriptBlock\Invoke-RemoteMain.ps1
 
-    $oldErrorAction = $ErrorActionPreference
-    $ErrorActionPreference = "Stop"
     try {
         $Script:VerboseFunctionCaller = ${Function:Write-ScriptDebug}
         $Script:HostFunctionCaller = ${Function:Write-ScriptHost}
@@ -267,7 +265,6 @@ Function Invoke-RemoteFunctions {
         Write-ScriptHost -WriteString ("Error Exception: {0}" -f $Error[0].Exception) -ForegroundColor "Red"
         Write-ScriptHost -WriteString ("Error Stack: {0}" -f $Error[0].ScriptStackTrace) -ForegroundColor "Red"
     } finally {
-        $ErrorActionPreference = $oldErrorAction
         Write-ScriptDebug("Exiting: Invoke-RemoteFunctions")
         Write-ScriptDebug("[double]TotalBytesSizeCopied: {0} | [double]TotalBytesSizeCompressed: {1} | [double]AdditionalFreeSpaceCushionGB: {2} | [double]CurrentFreeSpaceGB: {3} | [double]FreeSpaceMinusCopiedAndCompressedGB: {4}" -f $Script:TotalBytesSizeCopied,
             $Script:TotalBytesSizeCompressed,

--- a/src/ExchangeLogCollector/ExchangeServerInfo/Get-ExchangeBasicServerObject.ps1
+++ b/src/ExchangeLogCollector/ExchangeServerInfo/Get-ExchangeBasicServerObject.ps1
@@ -5,9 +5,6 @@ Function Get-ExchangeBasicServerObject {
     )
     Write-ScriptDebug("Function Enter: Get-ExchangeBasicServerObject")
     Write-ScriptDebug("Passed: [string]ServerName: {0}" -f $ServerName)
-    $oldErrorAction = $ErrorActionPreference
-    $ErrorActionPreference = "Stop"
-    $failure = $false
     try {
         $exchServerObject = New-Object PSCustomObject
         $exchServerObject | Add-Member -MemberType NoteProperty -Name ServerName -Value $ServerName
@@ -17,13 +14,7 @@ Function Get-ExchangeBasicServerObject {
         }
     } catch {
         Write-ScriptHost -WriteString ("Failed to detect server {0} as an Exchange Server" -f $ServerName) -ShowServer $false -ForegroundColor "Red"
-        $failure = $true
-    } finally {
-        $ErrorActionPreference = $oldErrorAction
-    }
-
-    if ($failure -eq $true) {
-        return $failure
+        return $null
     }
 
     $exchAdminDisplayVersion = $getExchangeServer.AdminDisplayVersion

--- a/src/ExchangeLogCollector/ExchangeServerInfo/Get-ExchangeServerDagName.ps1
+++ b/src/ExchangeLogCollector/ExchangeServerInfo/Get-ExchangeServerDagName.ps1
@@ -4,8 +4,6 @@ Function Get-ExchangeServerDAGName {
     )
     Write-ScriptDebug("Function Enter: Get-ExchangeServerDAGName")
     Write-ScriptDebug("Passed: [string]Server: {0}" -f $Server)
-    $oldErrorAction = $ErrorActionPreference
-    $ErrorActionPreference = "Stop"
     try {
         $dagName = (Get-MailboxServer $Server -ErrorAction Stop).DatabaseAvailabilityGroup.Name
         Write-ScriptDebug("Returning dagName: {0}" -f $dagName)
@@ -14,7 +12,5 @@ Function Get-ExchangeServerDAGName {
     } catch {
         Write-ScriptHost -WriteString ("Looks like this server {0} isn't a Mailbox Server. Unable to get DAG Information." -f $Server) -ShowServer $false
         return $null
-    } finally {
-        $ErrorActionPreference = $oldErrorAction
     }
 }

--- a/src/ExchangeLogCollector/ExchangeServerInfo/Get-ServerObjects.ps1
+++ b/src/ExchangeLogCollector/ExchangeServerInfo/Get-ServerObjects.ps1
@@ -7,8 +7,6 @@ Function Get-ServerObjects {
     Write-ScriptDebug ("Passed: {0} number of Servers" -f $ValidServers.Count)
     $svrsObject = @()
     $validServersList = @()
-    $oldErrorAction = $ErrorActionPreference
-    $ErrorActionPreference = "Stop"
     foreach ($svr in $ValidServers) {
         Write-ScriptDebug -stringdata ("Working on Server {0}" -f $svr)
 
@@ -42,7 +40,7 @@ Function Get-ServerObjects {
 
         $svrsObject += $sobj
     }
-    $ErrorActionPreference = $oldErrorAction
+
     if (($null -eq $svrsObject) -or
         ($svrsObject.Count -eq 0)) {
         Write-ScriptHost -WriteString ("Something wrong happened in Get-ServerObjects stopping script") -ShowServer $false -ForegroundColor "Red"

--- a/src/ExchangeLogCollector/RemoteScriptBlock/Test-CommandExists.ps1
+++ b/src/ExchangeLogCollector/RemoteScriptBlock/Test-CommandExists.ps1
@@ -2,16 +2,12 @@ Function Test-CommandExists {
     param(
         [string]$command
     )
-    $oldAction = $ErrorActionPreference
-    $ErrorActionPreference = "Stop"
 
     try {
-        if (Get-Command $command) {
+        if (Get-Command $command -ErrorAction Stop) {
             return $true
         }
     } catch {
         return $false
-    } finally {
-        $ErrorActionPreference = $oldAction
     }
 }

--- a/src/ExchangeLogCollector/Test-RemoteExecutionOfServers.ps1
+++ b/src/ExchangeLogCollector/Test-RemoteExecutionOfServers.ps1
@@ -25,13 +25,11 @@ Function Test-RemoteExecutionOfServers {
     Write-ScriptHost -WriteString "For all the servers that are up, we are going to see if remote execution will work" -ShowServer $false
     #shouldn't need to test if they are Exchange servers, as we should be doing that locally as well.
     $validServers = @()
-    $oldErrorAction = $ErrorActionPreference
-    $ErrorActionPreference = "Stop"
     foreach ($server in $serversUp) {
 
         try {
             Write-ScriptHost -WriteString ("Checking Server {0}....." -f $server) -ShowServer $false -NoNewLine $true
-            Invoke-Command -ComputerName $server -ScriptBlock { Get-Process | Out-Null }
+            Invoke-Command -ComputerName $server -ScriptBlock { Get-Process | Out-Null } -ErrorAction Stop
             #if that doesn't fail, we should be okay to add it to the working list
             Write-ScriptHost -WriteString ("Passed") -ShowServer $false -ForegroundColor "Green"
             $validServers += $server
@@ -41,6 +39,5 @@ Function Test-RemoteExecutionOfServers {
         }
     }
     Write-ScriptDebug("Function Exit: Test-RemoteExecutionOfServers")
-    $ErrorActionPreference = $oldErrorAction
     return $validServers
 }


### PR DESCRIPTION
Removed the changing of the Error Action Preferences because half the time you need to use the `-ErrorAction` switch in the command itself to get thrown into the catch block anyways.