### PR TITLE
Move receive connector and queue data info to Write-ExchangeDataOnMachines

### DIFF
--- a/.build/UpdateExternalFiles.ps1
+++ b/.build/UpdateExternalFiles.ps1
@@ -68,7 +68,7 @@ try {
 
             if ($foundExtra) {
                 $scriptContent.RemoveRange($startRemoveIndex, $count)
-                $scriptContent.Insert($startRemoveIndex, "#Function Version $reproScriptVersion")
+                $scriptContent.Insert($startRemoveIndex, "    #Function Version $reproScriptVersion")
             }
 
             $scriptContent.Insert(0,$reproScriptVersion)

--- a/src/ExchangeLogCollector/ExchangeServerInfo/Get-ExchangeObjectServerData.ps1
+++ b/src/ExchangeLogCollector/ExchangeServerInfo/Get-ExchangeObjectServerData.ps1
@@ -15,6 +15,7 @@ Function Get-ExchangeObjectServerData {
             }
             $obj | Add-Member -MemberType NoteProperty -Name TransportServerInfo -Value $hubInfo
             $obj | Add-Member -MemberType NoteProperty -Name ReceiveConnectors -Value (Get-ReceiveConnector -Server $server)
+            $obj | Add-Member -MemberType NoteProperty -Name QueueData -Value (Get-Queue -Server $server)
         }
         if ($obj.CAS) {
             if ($obj.Version -ge 16) {

--- a/src/ExchangeLogCollector/ExchangeServerInfo/Get-ExchangeObjectServerData.ps1
+++ b/src/ExchangeLogCollector/ExchangeServerInfo/Get-ExchangeObjectServerData.ps1
@@ -14,6 +14,7 @@ Function Get-ExchangeObjectServerData {
                 $hubInfo = Get-TransportServer $server
             }
             $obj | Add-Member -MemberType NoteProperty -Name TransportServerInfo -Value $hubInfo
+            $obj | Add-Member -MemberType NoteProperty -Name ReceiveConnectors -Value (Get-ReceiveConnector -Server $server)
         }
         if ($obj.CAS) {
             if ($obj.Version -ge 16) {

--- a/src/ExchangeLogCollector/ExchangeServerInfo/Get-TransportLoggingInformationPerServer.ps1
+++ b/src/ExchangeLogCollector/ExchangeServerInfo/Get-TransportLoggingInformationPerServer.ps1
@@ -62,12 +62,7 @@ Function Get-TransportLoggingInformationPerServer {
         Write-ScriptHost -WriteString ("trying to determine transport information for server {0} and wasn't able to determine the correct version type" -f $Server) -ShowServer $false
         return
     }
-    Write-ScriptDebug("ReceiveConnectors: {0} | QueueInformationThisServer: {1}" -f $ReceiveConnectors, $QueueInformationThisServer)
-
-    if ($ReceiveConnectors) {
-        $value = Get-ReceiveConnector -Server $Server
-        $transportLoggingObject | Add-Member -MemberType NoteProperty -Name ReceiveConnectorData -Value $value
-    }
+    Write-ScriptDebug("QueueInformationThisServer: {0}" -f $QueueInformationThisServer)
 
     if ($QueueInformationThisServer -and
         (-not($Version -eq 15 -and

--- a/src/ExchangeLogCollector/ExchangeServerInfo/Get-TransportLoggingInformationPerServer.ps1
+++ b/src/ExchangeLogCollector/ExchangeServerInfo/Get-TransportLoggingInformationPerServer.ps1
@@ -62,14 +62,6 @@ Function Get-TransportLoggingInformationPerServer {
         Write-ScriptHost -WriteString ("trying to determine transport information for server {0} and wasn't able to determine the correct version type" -f $Server) -ShowServer $false
         return
     }
-    Write-ScriptDebug("QueueInformationThisServer: {0}" -f $QueueInformationThisServer)
-
-    if ($QueueInformationThisServer -and
-        (-not($Version -eq 15 -and
-                $CASOnly))) {
-        $value = Get-Queue -Server $Server
-        $transportLoggingObject | Add-Member -MemberType NoteProperty -Name QueueData -Value $value
-    }
 
     Write-ScriptDebug("Function Exit: Get-TransportLoggingInformationPerServer")
     return $transportLoggingObject

--- a/src/ExchangeLogCollector/Get-ArgumentList.ps1
+++ b/src/ExchangeLogCollector/Get-ArgumentList.ps1
@@ -29,7 +29,6 @@ Function Get-ArgumentList {
     $obj | Add-Member -Name MailboxConnectivityLogs -MemberType NoteProperty -Value $MailboxConnectivityLogs
     $obj | Add-Member -Name MailboxProtocolLogs -MemberType NoteProperty -Value $MailboxProtocolLogs
     $obj | Add-Member -Name QueueInformationThisServer -MemberType NoteProperty -Value $QueueInformationThisServer
-    $obj | Add-Member -Name ReceiveConnectors -MemberType NoteProperty -Value $ReceiveConnectors
     $obj | Add-Member -Name SendConnectors -MemberType NoteProperty -Value $SendConnectors
     $obj | Add-Member -Name DAGInformation -MemberType NoteProperty -Value $DAGInformation
     $obj | Add-Member -Name GetVdirs -MemberType NoteProperty -Value $GetVdirs

--- a/src/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
+++ b/src/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
@@ -330,13 +330,6 @@ Function Invoke-RemoteMain {
             }
         }
 
-        if ($PassedInfo.ReceiveConnectors) {
-            $create = $Script:RootCopyToDirectory + "\Connectors"
-            New-Folder -NewFolder $create -IncludeDisplayCreate $true
-            $saveLocation = ($create + "\{0}_Receive_Connectors") -f $env:COMPUTERNAME
-            Save-DataInfoToFile -dataIn ($Script:localServerObject.TransportInfo.ReceiveConnectorData) -SaveToLocation $saveLocation
-        }
-
         if ($PassedInfo.TransportConfig) {
 
             if ($Script:localServerObject.Version -ge 15 -and (-not($Script:localServerObject.Edge))) {

--- a/src/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
+++ b/src/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
@@ -318,10 +318,6 @@ Function Invoke-RemoteMain {
         if ($PassedInfo.QueueInformationThisServer -and
             (-not ($Script:localServerObject.Version -eq 15 -and
                     $Script:localServerObject.CASOnly))) {
-            $create = $Script:RootCopyToDirectory + "\Queue_Data"
-            New-Folder -NewFolder $create -IncludeDisplayCreate $true
-            $saveLocation = $create + "\Current_Queue_Info"
-            Save-DataInfoToFile -dataIn ($Script:localServerObject.TransportInfo.QueueData) -SaveToLocation $saveLocation
 
             if ($Script:localServerObject.Version -ge 15 -and
                 $null -ne $Script:localServerObject.TransportInfo.HubLoggingInfo.QueueLogPath) {

--- a/src/ExchangeLogCollector/RemoteScriptBlock/extern/Compress-Folder.ps1
+++ b/src/ExchangeLogCollector/RemoteScriptBlock/extern/Compress-Folder.ps1
@@ -10,7 +10,7 @@ Function Compress-Folder {
         [Parameter(Mandatory = $false)][bool]$ReturnCompressedLocation = $false,
         [Parameter(Mandatory = $false, Position = 1)][object]$PassedObjectParameter
     )
-#Function Version #v21.01.08.2133
+    #Function Version #v21.01.08.2133
 
     Function Get-DirectorySize {
         param(

--- a/src/ExchangeLogCollector/RemoteScriptBlock/extern/Get-ExchangeInstallDirectory.ps1
+++ b/src/ExchangeLogCollector/RemoteScriptBlock/extern/Get-ExchangeInstallDirectory.ps1
@@ -6,7 +6,7 @@ Function Get-ExchangeInstallDirectory {
     param(
         [Parameter(Mandatory = $false)][bool]$InvokeCommandReturnWriteArray
     )
-#Function Version #v21.01.08.2133
+    #Function Version #v21.01.08.2133
 
     $stringArray = @()
     Write-InvokeCommandReturnVerboseWriter("Calling: Get-ExchangeInstallDirectory")

--- a/src/ExchangeLogCollector/RemoteScriptBlock/extern/Get-FreeSpace.ps1
+++ b/src/ExchangeLogCollector/RemoteScriptBlock/extern/Get-FreeSpace.ps1
@@ -8,7 +8,7 @@ Function Get-FreeSpace {
         [Parameter(Mandatory = $false)][ValidateScript( { $_.ToString().EndsWith("\") })][string]$FilePath,
         [Parameter(Mandatory = $false, Position = 1)][object]$PassedObjectParameter
     )
-#Function Version #v21.01.08.2133
+    #Function Version #v21.01.08.2133
 
     if ($null -ne $PassedObjectParameter) {
         if ($null -ne $PassedObjectParameter.FilePath) {

--- a/src/ExchangeLogCollector/RemoteScriptBlock/extern/New-Folder.ps1
+++ b/src/ExchangeLogCollector/RemoteScriptBlock/extern/New-Folder.ps1
@@ -10,7 +10,7 @@ Function New-Folder {
         [Parameter(Mandatory = $false)][bool]$IncludeDisplayCreate,
         [Parameter(Mandatory = $false, Position = 1)][object]$PassedParametersObject
     )
-#Function Version #v21.01.08.2133
+    #Function Version #v21.01.08.2133
 
     Function New-Directory {
         param(

--- a/src/ExchangeLogCollector/Test-PossibleCommonScenarios.ps1
+++ b/src/ExchangeLogCollector/Test-PossibleCommonScenarios.ps1
@@ -75,6 +75,11 @@ Function Test-PossibleCommonScenarios {
         $Script:ServerInfo = $true
     }
 
+    #Because we right out our Receive Connector information in Exchange Server Info now
+    if ($ReceiveConnectors) {
+        $Script:ExchangeServerInfo = $true
+    }
+
     #See if any transport logging is enabled.
     $Script:AnyTransportSwitchesEnabled = $false
     if ($HubProtocolLogs -or

--- a/src/ExchangeLogCollector/Test-PossibleCommonScenarios.ps1
+++ b/src/ExchangeLogCollector/Test-PossibleCommonScenarios.ps1
@@ -76,7 +76,8 @@ Function Test-PossibleCommonScenarios {
     }
 
     #Because we right out our Receive Connector information in Exchange Server Info now
-    if ($ReceiveConnectors) {
+    if ($ReceiveConnectors -or
+        $QueueInformationThisServer) {
         $Script:ExchangeServerInfo = $true
     }
 

--- a/src/ExchangeLogCollector/Write/Write-ExchangeDataOnMachines.ps1
+++ b/src/ExchangeLogCollector/Write/Write-ExchangeDataOnMachines.ps1
@@ -68,6 +68,7 @@ Function Write-ExchangeDataOnMachines {
         if ($ServerData.Hub) {
             Save-DataToFile -DataIn $ServerData.TransportServerInfo -SaveToLocation ("{0}_TransportServer" -f $tempLocation)
             Save-DataToFile -DataIn $ServerData.ReceiveConnectors -SaveToLocation ("{0}_ReceiveConnectors" -f $tempLocation)
+            Save-DataToFile -DataIn $ServerData.QueueData -SaveToLocation ("{0}_InstantQueueInfo" -f $tempLocation)
         }
         if ($ServerData.CAS) {
             Save-DataToFile -DataIn $ServerData.CAServerInfo -SaveToLocation ("{0}_ClientAccessServer" -f $tempLocation)

--- a/src/ExchangeLogCollector/Write/Write-ExchangeDataOnMachines.ps1
+++ b/src/ExchangeLogCollector/Write/Write-ExchangeDataOnMachines.ps1
@@ -1,3 +1,6 @@
+#This function job is to write out the Data that is too large to pass into the main script block
+#This is for mostly Exchange Related objects.
+#To handle this, we export the data locally and copy the data over the correct server.
 Function Write-ExchangeDataOnMachines {
 
     Function Write-ExchangeData {
@@ -6,14 +9,6 @@ Function Write-ExchangeDataOnMachines {
         )
 
         $location = $PassedInfo.Location
-        Function Write-Data {
-            param(
-                [Parameter(Mandatory = $true)][object]$DataIn,
-                [Parameter(Mandatory = $true)][string]$FilePathNoEXT
-            )
-            $DataIn | Format-List * > "$FilePathNoEXT.txt"
-            $DataIn | Export-Clixml "$FilePathNoEXT.xml"
-        }
         $exchBin = "{0}\Bin" -f $PassedInfo.InstallDirectory
         $configFiles = Get-ChildItem $exchBin | Where-Object { $_.Name -like "*.config" }
         $copyTo = "{0}\Config" -f $location
@@ -72,6 +67,7 @@ Function Write-ExchangeDataOnMachines {
 
         if ($ServerData.Hub) {
             Save-DataToFile -DataIn $ServerData.TransportServerInfo -SaveToLocation ("{0}_TransportServer" -f $tempLocation)
+            Save-DataToFile -DataIn $ServerData.ReceiveConnectors -SaveToLocation ("{0}_ReceiveConnectors" -f $tempLocation)
         }
         if ($ServerData.CAS) {
             Save-DataToFile -DataIn $ServerData.CAServerInfo -SaveToLocation ("{0}_ClientAccessServer" -f $tempLocation)


### PR DESCRIPTION
By moving this there, we remove any additional large objects from being in the main action of the remote script block execution.