### PR TITLE
Handle each task better

### DIFF
--- a/src/ExchangeLogCollector/RemoteScriptBlock/IO/Copy-FullLogFullPathRecurse.ps1
+++ b/src/ExchangeLogCollector/RemoteScriptBlock/IO/Copy-FullLogFullPathRecurse.ps1
@@ -15,7 +15,8 @@ Function Copy-FullLogFullPathRecurse {
             }
         }
 
-        if ($null -ne $items) {
+        if ($null -ne $items -and
+            $items.Count -gt 0) {
             if (Test-FreeSpace -FilePaths $items) {
                 Copy-Item $LogPath\* $CopyToThisLocation -Recurse -ErrorAction SilentlyContinue
                 Invoke-ZipFolder $CopyToThisLocation

--- a/src/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
+++ b/src/ExchangeLogCollector/RemoteScriptBlock/Invoke-RemoteMain.ps1
@@ -427,7 +427,13 @@ Function Invoke-RemoteMain {
     #Execute the cmds
     foreach ($cmd in $cmdsToRun) {
         Write-ScriptDebug("cmd: {0}" -f $cmd)
-        Invoke-Expression $cmd
+
+        try {
+            & $cmd
+        } catch {
+            Write-ScriptDebug("Failed to finish running command: $cmd")
+            #TODO Add Error Information Here.
+        }
     }
 
     if ((-not($PassedInfo.ExchangeServerInfo)) -and

--- a/src/ExchangeLogCollector/RemoteScriptBlock/Test-FreeSpace.ps1
+++ b/src/ExchangeLogCollector/RemoteScriptBlock/Test-FreeSpace.ps1
@@ -1,8 +1,15 @@
 Function Test-FreeSpace {
     param(
-        [Parameter(Mandatory = $true)][array]$FilePaths
+        [Parameter(Mandatory = $false)][array]$FilePaths
     )
     Write-ScriptDebug("Calling: Test-FreeSpace")
+
+    if ($null -eq $FilePaths -or
+        $FilePaths.Count -eq 0) {
+        Write-ScriptDebug("Null FilePaths provided returning true.")
+        return $true
+    }
+
     $passed = $true
     $currentSizeCopy = Get-ItemsSize -FilePaths $FilePaths
     #It is better to be safe than sorry, checking against probably a value way higher than needed.


### PR DESCRIPTION
Handled the empty files better in the copy actions and added a try catch to each command that we run remotely. This allowing all possible logs to get collected if one action just fails.

Resolved #128 