### PR TITLE
Update Logman collection of Experfwiz and Exmon

### DIFF
--- a/src/ExchangeLogCollector/ExchangeLogCollector.ps1
+++ b/src/ExchangeLogCollector/ExchangeLogCollector.ps1
@@ -171,7 +171,7 @@ Param (
     [switch]$PerformanceIssues,
     [switch]$PerformanceMailflowIssues,
     [switch]$OutlookConnectivityIssues,
-    [string]$ExperfwizLogmanName = "Exchange_Perfwiz",
+    [array]$ExperfwizLogmanName = @("Exchange_Perfwiz", "ExPerfwiz"),
     [string]$ExmonLogmanName = "Exmon_Trace",
     [switch]$AcceptEULA,
     [switch]$ScriptDebug

--- a/src/ExchangeLogCollector/RemoteScriptBlock/IO/Save-LogmanExperfwizData.ps1
+++ b/src/ExchangeLogCollector/RemoteScriptBlock/IO/Save-LogmanExperfwizData.ps1
@@ -1,3 +1,7 @@
 Function  Save-LogmanExperfwizData {
-    Get-LogmanData -LogmanName $PassedInfo.ExperfwizLogmanName -ServerName $env:COMPUTERNAME
+
+    $PassedInfo.ExperfwizLogmanName |
+        ForEach-Object {
+            Get-LogmanData -LogmanName $_ -ServerName $env:COMPUTERNAME
+        }
 }


### PR DESCRIPTION
Update Logman collection of Experfwiz and Exmon to allow for multiple names to be looked up. This allows both the old name and the new name of experfwiz to be collected automatically. As well as if you have different names.