### PR TITLE
Added CollectOverMetrics.ps1 script collection option

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ ADDriverLogs | Enable to collect AD Driver Logs. Location: `V15\Logging\ADDriver
 AppSysLogs | Collects the Windows Event Application, System, and MSExchange Management Logs. Default value `$true`
 AppSysLogsToXml | Collects the Windows Event Application and System and saves them out to XML. The date range only is from the time the script run and the value set on `DaysWorth`. Default value: `$true`
 AutoDLogs | Enable to collect AutoDiscover Logs. Location: `V15\Logging\Autodiscover` and `V15\Logging\HttpProxy\Autodiscover`
+CollectFailoverMetrics | Enable to run the `CollectOverMetrics.ps1` script against the DAG. Only able to be run on an Exchange tools box or an Exchange Server.
 DAGInformation | Enable to collect the DAG Information from all different DAGs that are in the list of servers.
 DailyPerformanceLogs | Enable to collect Daily Performance Logs. Default Location: `V15\Logging\Diagnostics\DailyPerformanceLogs`
 DefaultTransportLogging | Enables the following switches and their logs to be collected. `FrontEndConnectivityLogs`, `FrontEndProtocolLogs`, `HubConnectivityLogs`, `MailboxConnectivityLogs`, `MailboxDeliveryThrottlingLogs`, `MessageTrackingLogs`, `QueueInformation`, `ReceiveConnectors`, `SendConnectors`, and `TransportConfig`

--- a/src/ExchangeLogCollector/ExchangeLogCollector.ps1
+++ b/src/ExchangeLogCollector/ExchangeLogCollector.ps1
@@ -22,6 +22,7 @@ Param (
     [bool]$AppSysLogs = $true,
     [bool]$AppSysLogsToXml = $true,
     [switch]$AutoDLogs,
+    [switch]$CollectFailoverMetrics,
     [switch]$DAGInformation,
     [switch]$DailyPerformanceLogs,
     [switch]$DefaultTransportLogging,
@@ -225,6 +226,10 @@ Function Main {
     if (!($Script:LocalExchangeShell.ShellLoaded)) {
         Write-ScriptHost -WriteString ("It appears that you are not on an Exchange 2010 or newer server. Sorry I am going to quit.") -ShowServer $false
         exit
+    }
+
+    if (!$Script:LocalExchangeShell.RemoteShell) {
+        $Script:localExInstall = Get-ExchangeInstallDirectory
     }
 
     if (!$Script:LocalExchangeShell.ToolsOnly -and

--- a/src/ExchangeLogCollector/Helpers/Test-PossibleCommonScenarios.ps1
+++ b/src/ExchangeLogCollector/Helpers/Test-PossibleCommonScenarios.ps1
@@ -27,6 +27,7 @@ Function Test-PossibleCommonScenarios {
         $Script:OABLogs = $true
         $Script:PowerShellLogs = $true
         $Script:WindowsSecurityLogs = $true
+        $Script:CollectFailoverMetrics = $true
     }
 
     if ($DefaultTransportLogging) {
@@ -49,6 +50,7 @@ Function Test-PossibleCommonScenarios {
         $Script:DAGInformation = $true
         $Script:Experfwiz = $true
         $Script:ServerInformation = $true
+        $Script:CollectFailoverMetrics = $true
     }
 
     if ($PerformanceIssues) {


### PR DESCRIPTION
Added the ability to run the CollectOverMetrics.ps1 script on the servers. We are able to only do this if the local machine that is executing the script is an Exchange Server or a tools box. Otherwise, we aren't able to run this as we can't invoke the script inside of a Invoke-Command.

Resolved #22