### PR TITLE
Fixed issue with trying to remove folders that were never created

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,5 +15,6 @@
     "powershell.codeFormatting.whitespaceBeforeOpenParen": true,
     "powershell.codeFormatting.whitespaceBetweenParameters": false,
     "powershell.codeFormatting.whitespaceInsideBrace": true,
-    "powershell.codeFormatting.addWhitespaceAroundPipe": true
+    "powershell.codeFormatting.addWhitespaceAroundPipe": true,
+    "files.trimTrailingWhitespace": true
 }


### PR DESCRIPTION
If there isn't a DAG, don't go into the sections that that remove a folder that doesn't get created when there isn't a single DAG in the list.